### PR TITLE
Fix initialization error with stream-type books

### DIFF
--- a/eb4j-core/src/main/java/fuku/eb4j/SubBook.java
+++ b/eb4j-core/src/main/java/fuku/eb4j/SubBook.java
@@ -110,7 +110,9 @@ public class SubBook {
             _setupEPWING(path, fname, format, narrow, wide);
         }
 
-        _load();
+        if (_text != null) {
+            _load();
+        }
 
         // 半角/全角両方存在するものを選択
         int len = _fonts.length;
@@ -167,9 +169,22 @@ public class SubBook {
         _name = dir.getName();
 
         // データディレクトリ
-        File dataDir = EBFile.searchDirectory(dir, "data");
-        // 本文データファイル
-        _text = new EBFile(dataDir, fname[0], format[0]);
+        // 存在しない場合がある。ebライブラリのsubbook.cから：
+        /*
+         * If a subbook has stream data only, its index_page has been set to 0.
+         * In this case, we must not try to open a text file of the subbook,
+         * since the text file may be for another subbook. Remember that
+         * subbooks can share a `data' sub-directory.
+         */
+        File dataDir = null;
+        try {
+            dataDir = EBFile.searchDirectory(dir, "data");
+        } catch (EBException e) {
+        }
+        if (dataDir != null) {
+            // 本文データファイル
+            _text = new EBFile(dataDir, fname[0], format[0]);
+        }
         // 画像データファイル
         if (fname[1] != null) {
             try {


### PR DESCRIPTION
fixes #2 

The immediate cause of the exception is that eb4j looks for a non-existent `data` directory for subbook 3, "ＥＰＷＩＮＧ　紹介", which epwutil's `catdump` shows to be of booktype `F004 (F0:ストリーム, 04:EPWING4)`.

I dug up the source to the [EB Library](https://web.archive.org/web/20120330123930/http://www.sra.co.jp/people/m-kasahr/eb/) and it had a some relevant information in `subbook.c`:
```
   * If a subbook has stream data only, its index_page has been set
   * to 0.  In this case, we must not try to open a text file of
   * the subbook, since the text file may be for another subbook.
   * Remember that subbooks can share a `data' sub-directory.
```
In the analogous section of eb4j I find that subbook 3 does indeed have `index == 0`, so I have modified the initialization code to follow EB Library's example and simply allow for the `_text` member to remain null.

Here is the output of EB Library's `ebinfo`:
```
disc type: EPWING
character code: JIS X 0208
the number of subbooks: 4

subbook 1:
  title: 現代新国語辞典
  directory: kokugo
  search methods: word endword multi menu copyright 
  font sizes: 16 24 
  narrow font characters: 0xa121 -- 0xa420
  wide font characters: 0xa121 -- 0xa420

subbook 2:
  title: 漢字源
  directory: kanjigen
  search methods: word endword multi menu copyright 
  font sizes: 16 24 
  narrow font characters: 0xa121 -- 0xa236
  wide font characters: 0xa121 -- 0xa236

subbook 3:
  title: ＥＰＷＩＮＧ　紹介
  directory: epwdemo
  search methods: 
  font sizes: 
  narrow font characters: 
  wide font characters: 

subbook 4:
  title: 書籍選択
  directory: screen
  search methods: 
  font sizes: 
  narrow font characters: 
  wide font characters: 
```

With this patch, eb4j's `EBInfo` tool gives the same output (modulo whitespace and directory case), and using the patched version of eb4j in [miurahr/omegat-plugin-epwing](https://github.com/miurahr/omegat-plugin-epwing) allows me to use the Gakken EPWING dictionaries I mentioned in issue #2.